### PR TITLE
Add Acknowledgements section to README mentioning Ragtag and @jdegrazia

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,14 @@ alembic upgrade head
 # Future work
 
 See our public Pivotal Tracker project for planned work: https://www.pivotaltracker.com/n/projects/1996883
+
+# Acknowledgements
+
+This project was born under the umbrella of [Ragtag](https://ragtag.org), a
+volunteer team of technologists working for progressive change. Consider
+[joining Ragtag](https://ragtag.org/join/) or
+[donating](https://opencollective.com/ragtag) to help defray our operating
+costs.
+
+This project was instigated by @jdegrazia, who continues to shepherd it with
+encouragement from @jillh510 and coding help from @anaulin.


### PR DESCRIPTION
This PR adds a small blurb mentioning that this project is part of Ragtag, and who are the main collaborators in the project.

@jillh510 and @jdegrazia please have a look and let me know if you're ok with this being submitted into the Bidwire README, or if you have any other suggestions