### PR TITLE
Make it possible to set the email recipient list via an environment variable

### DIFF
--- a/bidwire_settings.py
+++ b/bidwire_settings.py
@@ -2,3 +2,15 @@ import os
 
 POSTGRES_ENDPOINT = os.environ.get('POSTGRES_ENDPOINT', 'localhost')
 SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
+
+
+def get_recipients_list():
+    # The env variable should contain a comma-separated recipient list.
+    recipients_str = os.environ.get('EMAIL_RECIPIENTS',
+                                    'bidwire-logs@googlegroups.com')
+    # Split into array of strings and strip whitespace.
+    return [r.strip() for r in recipients_str.split(',')]
+
+
+# List of e-mail recipients. Array of e-mail addresses.
+EMAIL_RECIPIENTS = get_recipients_list()

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 """Main BidWire entrypoint"""
 
-import logging
-import scraper
 import bid
+import bidwire_settings
+import logging
 import notifier
+import scraper
 
 if __name__ == '__main__':
     # Configure logging
@@ -13,4 +14,5 @@ if __name__ == '__main__':
     # Retrieve the bids we found in the last 23 hours -- if we
     # scrape once a day, this means the new bids in the last scrape.
     new_bids = bid.get_bids_from_last_n_hours(23)
-    notifier.send_new_bids_notification(new_bids)
+    notifier.send_new_bids_notification(new_bids,
+                                        bidwire_settings.EMAIL_RECIPIENTS)

--- a/notifier.py
+++ b/notifier.py
@@ -10,7 +10,7 @@ ADMIN_EMAIL = "bidwire-admin@googlegroups.com"
 log = logging.getLogger(__name__)
 
 
-def send_new_bids_notification(bids, recipients=["bidwire-logs@googlegroups.com"]):
+def send_new_bids_notification(bids, recipients):
     log.info("Sending notifications to {} about bids {}".format(recipients,
                                                                 bids))
     sg = sendgrid.SendGridAPIClient(apikey=os.environ.get('SENDGRID_API_KEY'))


### PR DESCRIPTION
This is so that we can set the recipient in our Heroku configuration, instead of having to commit the intended recipients' email addresses to our public repo.