### PR TITLE
Scrape also Memphis Council "agendas" and "schedules" columns

### DIFF
--- a/bidwire/manage.py
+++ b/bidwire/manage.py
@@ -45,13 +45,13 @@ def get_site_config(site_str, recipients=None):
 
 def to_site_enum(site_str):
     """Turns a string into a site Enum, or raises exception."""
-    site = Bid.Site[site_str]
-    if site:
-        return site
-    site = Document.Site[site_str]
-    if site:
-        return site
-    raise ValueError("Couldn't find Site enum for {}".format(site_str))
+    try:
+        return Bid.Site[site_str]
+    except:
+        try:
+            return Document.Site[site_str]
+        except:
+            raise ValueError("Couldn't find Site enum for {}".format(site_str))
 
 
 if __name__ == '__main__':

--- a/bidwire/scrapers/memphis_council_calendar_scraper.py
+++ b/bidwire/scrapers/memphis_council_calendar_scraper.py
@@ -59,7 +59,8 @@ class MemphisCouncilCalScraper(BaseScraper):
                     row.text_content()))
                 continue
             date_str = cells[0].text.strip()  # Something like "Jan 3"
-            doc_links = cells[3].xpath('a')
+            # Extract the links from the agenda, schedule and documents columns
+            doc_links = cells[3].xpath('a') + cells[1].xpath('a') + cells[2].xpath('a')
             for link in doc_links:
                 hrefs = link.xpath('@href')
                 if len(hrefs) < 1:

--- a/bidwire/tests/test_memphis_council_calendar_scraper.py
+++ b/bidwire/tests/test_memphis_council_calendar_scraper.py
@@ -7,7 +7,7 @@ def test_get_docs_from_page():
     page_str = open(utils.get_abs_filename(
         'memphis-city-council-calendar.html'), 'r').read()
     docs = memphis_scraper._get_docs_from_calendar(page_str)
-    assert len(docs) == 26
+    assert len(docs) == 47
     for doc in docs:
         # All URLs should be absolute.
         assert doc.url.startswith("http://")


### PR DESCRIPTION
Also fixes broken string-to-enum logic in manage.py.