### PR TITLE
Make execute_parallel slightly more elegant, using executor.map

### DIFF
--- a/bidwire/scrapers/cityofboston_scraper.py
+++ b/bidwire/scrapers/cityofboston_scraper.py
@@ -39,8 +39,7 @@ class CityOfBostonScraper(BaseScraper):
         bid_ids = self.scrape_results_page(page.content)
         log.info("Found bid ids: {}".format(bid_ids))
         new_ids = get_new_identifiers(session, bid_ids, self.get_site())
-        arg_tuples = [(self.scrape_bid_page, bid_id) for bid_id in new_ids]
-        bids = execute_parallel(arg_tuples)
+        bids = execute_parallel(self.scrape_bid_page, new_ids)
         session.bulk_save_objects(bids)
         session.commit()
 

--- a/bidwire/scrapers/commbuys_scraper.py
+++ b/bidwire/scrapers/commbuys_scraper.py
@@ -49,11 +49,8 @@ class CommBuysScraper(BaseScraper):
                 break
             new_ids = get_new_identifiers(session, bid_ids, self.get_site())
             # Scrape in parallel the new bid ids found.
-            # Any underlying exceptions are allowed to propagate to the caller, and
-            # will abort the entire scraping process.
-            arg_tuples = [(self.scrape_bid_page, bid_id) for bid_id in new_ids]
             try:
-                bids = execute_parallel(arg_tuples)
+                bids = execute_parallel(self.scrape_bid_page, new_ids)
             except Exception as err:
                 log.error("Caught exception during bid detail scraping: {}".format(err))
             session.bulk_save_objects(bids)

--- a/bidwire/tests/test_utils.py
+++ b/bidwire/tests/test_utils.py
@@ -11,7 +11,6 @@ class Accumulator:
 
 
 def test_parallel():
-    results = execute_parallel(
-        [(Accumulator.accumulate, 1), (Accumulator.accumulate, 3)])
-    assert len(results) == 2
+    results = execute_parallel(Accumulator.accumulate, [1, 3])
+    assert len(list(results)) == 2
     assert Accumulator.accumulator == 4  # 1 and 3 were accumulated

--- a/bidwire/utils.py
+++ b/bidwire/utils.py
@@ -1,22 +1,22 @@
 import concurrent.futures
 
+def execute_parallel(fn, *iterables, num_threads=4):
+    """A helper function to perform a function on different arguments in parallel.
 
-def execute_parallel(arg_tuples, num_threads=4):
-    """A helper function to perform some operations in parallel on a threadpool.
+    This is a thin wrapper on top of concurrent.futures.Executor.map. See:
+    https://docs.python.org/3/library/concurrent.futures.html
 
     Arguments:
-    arg_tuples -- a list of tuples that represent the arguments to be submitted
-       into the executor; typically the first element of the tuple will a
-       function, and the rest will be the arguments for the function
+    fn -- the function to execute
+    iterables -- the iterable with arguments to pass to func in different invocations;
+        if more than one iterable is provided, then func must take that number of arguments
     num_threads (optional) -- the number of parallel threads to use
 
     Returns:
-    a list with the results of executing arg_tuples
+    a generator with the results of executing arg_tuples
 
     Raises:
     any exception that is raised by the underlying execution
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
-        futures = [executor.submit(*args) for args in arg_tuples]
-        return [f.result()
-                for f in concurrent.futures.as_completed(futures)]
+        return executor.map(fn, *iterables)


### PR DESCRIPTION
Based on an example in @LogicalDash's PR https://github.com/RagtagOpen/bidwire/pull/48 .