### PR TITLE
Make all MASSGOV_EOPSS urls absolute from here onwards

### DIFF
--- a/bidwire/alembic/versions/a1b42c9006a7_absolute_massgov_eopss_url.py
+++ b/bidwire/alembic/versions/a1b42c9006a7_absolute_massgov_eopss_url.py
@@ -1,0 +1,44 @@
+"""absolute_massgov_eopss_url
+
+Revision ID: a1b42c9006a7
+Revises: 9b30b0fe231a
+Create Date: 2017-06-26 00:02:45.998655
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm.session import Session
+
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from document import Document
+from urllib import parse
+
+# revision identifiers, used by Alembic.
+revision = 'a1b42c9006a7'
+down_revision = '9b30b0fe231a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    def ensure_absolute(url):
+        root_url = "https://www.mass.gov/"
+        if not url.startswith(root_url):
+            return parse.urljoin(root_url, url)
+        return url
+
+    # Attach to the migration's session
+    session = Session(bind=op.get_bind())
+    docs = session.query(Document).filter(
+        Document.site == Document.Site.MASSGOV_EOPSS.name).all()
+    for doc in docs:
+        doc.url = ensure_absolute(doc.url)
+    session.add_all(docs)
+    session.commit()
+
+
+def downgrade():
+    # Do nothing for the rollback.
+    pass

--- a/bidwire/document.py
+++ b/bidwire/document.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 from sqlalchemy import Column, Integer, String, DateTime, func, Text, JSON
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import validates
 from enum import Enum
+
 
 Base = declarative_base()
 
@@ -32,11 +34,10 @@ class Document(Base):
         assert site in known_sites, "{} isn't a known Document.Site".format(site)
         return site
 
-    def get_url(self):
-        # TODO(anaulin): We should probably be storing absolute URLs for all sites, instead of composing this here
-        if self.site == Document.Site.MASSGOV_EOPSS.name:
-            return "https://www.mass.gov/" + self.url
-        return self.url
+    @validates('url')
+    def validate_url(self, key, url):
+        assert bool(urlparse(url).netloc), "{} should be an absolute URL".format(url)
+        return url
 
     def __repr__(self):
         return "<Document(id={}, url={}, title={}, created_at={})>".format(

--- a/bidwire/manage.py
+++ b/bidwire/manage.py
@@ -18,6 +18,10 @@ def scrape(site=''):
     """runs scraper for given <site>"""
     scraper.scrape(get_site_config(site))
 
+@manager.command
+def scrape_all_docs():
+    for site in Document.Site:
+        scraper.scrape(get_site_config(site.name))
 
 @manager.command
 def notify(site='', recipients=''):

--- a/bidwire/notifiers/notifier_utils.py
+++ b/bidwire/notifiers/notifier_utils.py
@@ -78,6 +78,6 @@ def make_doc_item_body(document):
     """Returns the HTML for one Document item"""
     doc, tag, text = Doc().tagtext()
     with tag('strong'):
-        with tag('a', href=document.get_url()):
+        with tag('a', href=document.url()):
             text(document.title)
     return doc.getvalue()

--- a/bidwire/notifiers/notifier_utils.py
+++ b/bidwire/notifiers/notifier_utils.py
@@ -78,6 +78,6 @@ def make_doc_item_body(document):
     """Returns the HTML for one Document item"""
     doc, tag, text = Doc().tagtext()
     with tag('strong'):
-        with tag('a', href=document.url()):
+        with tag('a', href=document.url):
             text(document.title)
     return doc.getvalue()

--- a/bidwire/scrapers/knox_tn_agendas_scraper.py
+++ b/bidwire/scrapers/knox_tn_agendas_scraper.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 from document import Document
 from scrapers.base_scraper import BaseScraper
+from utils import ensure_absolute_url
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ class KnoxCoTNAgendaScraper(BaseScraper):
                 log.error("Knox Agendas: no href in the anchor tag for %s: %s", agenda_date, meeting_name)
                 raise ValueError('no href in document anchor')
 
-            doc_url = self._ensure_absolute_url(doc_url)
+            doc_url = ensure_absolute_url(self.SITE_ROOT_URL, doc_url)
 
             # The anchor title is useless, so use the meeting name in the doc name
             doc_name = "{}: {}".format(agenda_date, meeting_name)
@@ -92,9 +93,3 @@ class KnoxCoTNAgendaScraper(BaseScraper):
             )
 
         return documents
-
-    def _ensure_absolute_url(self, url):
-        """If the given URL is relative, makes it absolute by prepending the site root URL."""
-        if not url.startswith(self.SITE_ROOT_URL):
-            return parse.urljoin(self.SITE_ROOT_URL, url)
-        return url

--- a/bidwire/scrapers/massgov/results_page_scraper.py
+++ b/bidwire/scrapers/massgov/results_page_scraper.py
@@ -1,5 +1,9 @@
 from lxml import etree, html
 
+from utils import ensure_absolute_url
+
+
+SITE_ROOT = 'https://www.mass.gov'
 
 def scrape_results_page(page_str, xpath_list):
     """Scrapes HTML page and returns dictionary of URL => document title
@@ -19,5 +23,6 @@ def scrape_results_page(page_str, xpath_list):
     for doc in document_list:
         elems = doc.xpath(doc_xpath)
         if elems:
-            document_ids[elems[0].get('href')] = elems[0].text.strip()
+            url = ensure_absolute_url(SITE_ROOT, elems[0].get('href'))
+            document_ids[url] = elems[0].text.strip()
     return document_ids

--- a/bidwire/scrapers/memphis_council_calendar_scraper.py
+++ b/bidwire/scrapers/memphis_council_calendar_scraper.py
@@ -8,6 +8,7 @@ import db
 
 from .base_scraper import BaseScraper
 from document import Document, get_new_urls
+from utils import ensure_absolute_url
 
 
 log = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class MemphisCouncilCalScraper(BaseScraper):
                     log.error("Unexpected number of hrefs in link: {}".format(
                         link.text_content()))
                     continue
-                doc_url = self._ensure_absolute_url(hrefs[0])
+                doc_url = ensure_absolute_url(self.SITE_ROOT_URL, hrefs[0])
                 # Because the text in the links is often the same (e.g "Council Documents"), we add
                 # the date string to the title to help disambiguate
                 doc_title = "{}: {}".format(date_str, link.text.strip())
@@ -77,9 +78,3 @@ class MemphisCouncilCalScraper(BaseScraper):
                     site=Document.Site.MEMPHIS_COUNCIL_CALENDAR.name
                 ))
         return documents
-
-    def _ensure_absolute_url(self, url):
-        """If the given URL is relative, makes it absolute by prepending the site root URL."""
-        if not url.startswith(MemphisCouncilCalScraper.SITE_ROOT_URL):
-            return urllib.parse.urljoin(MemphisCouncilCalScraper.SITE_ROOT_URL, url)
-        return url

--- a/bidwire/tests/factories.py
+++ b/bidwire/tests/factories.py
@@ -29,6 +29,6 @@ class DocumentFactory(factory.alchemy.SQLAlchemyModelFactory):
         # Test-only scoped session
         sqlalchemy_session = common.Session
 
-    url = factory.Sequence(lambda n: "Document-%s-%s" % (time.time(),
+    url = factory.Sequence(lambda n: "http://Document-%s-%s" % (time.time(),
                                                            random.random()))
     site = document.Document.Site.MASSGOV_EOPSS.name

--- a/bidwire/tests/test_document.py
+++ b/bidwire/tests/test_document.py
@@ -8,10 +8,10 @@ from . import factories
 
 
 class TestDocument():
-    def test_get_url_massgov_eopss(self):
-        document = factories.DocumentFactory(site=Document.Site.MASSGOV_EOPSS.name)
-        url = document.get_url()
-        assert "mass.gov" in url
+    def test_validates_url_is_absolute(self):
+        with pytest.raises(AssertionError) as exception_info:
+            factories.DocumentFactory(url="/some-href")
+        assert "absolute" in str(exception_info.value)
 
     def test_get_doc_count_per_site(self):
 	# Make sure the database contains at least one bid for each Site

--- a/bidwire/tests/test_massgov_scraper.py
+++ b/bidwire/tests/test_massgov_scraper.py
@@ -8,6 +8,6 @@ def test_scrape_results_page():
     xpath_list = ['//ul[@class="category"]/li', './h2/span/a[@class="titlelink"]']
     url_dict = results_page_scraper.scrape_results_page(page_str, xpath_list)
     assert len(url_dict) == 2
-    assert "/eopss/docs/ogr/homesec/ffy2017-bidders-conference-presentation-hsgp.pdf" \
+    assert "https://www.mass.gov/eopss/docs/ogr/homesec/ffy2017-bidders-conference-presentation-hsgp.pdf" \
            in url_dict.keys()
     assert "FFY 2017 Bidder's General Information Presentation" in url_dict.values()

--- a/bidwire/utils.py
+++ b/bidwire/utils.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+from urllib import parse
 
 def execute_parallel(fn, *iterables, num_threads=4):
     """A helper function to perform a function on different arguments in parallel.
@@ -12,7 +13,7 @@ def execute_parallel(fn, *iterables, num_threads=4):
         if more than one iterable is provided, then func must take that number of arguments
     num_threads (optional) -- the number of parallel threads to use
 
-    Returns:
+    Returnss
     a generator with the results of executing arg_tuples
 
     Raises:
@@ -20,3 +21,10 @@ def execute_parallel(fn, *iterables, num_threads=4):
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
         return executor.map(fn, *iterables)
+
+
+def ensure_absolute_url(site_root, url):
+    """If the given URL is relative, makes it absolute by prepending the site root URL."""
+    if not url.startswith(site_root):
+        return parse.urljoin(site_root, url)
+    return url

--- a/bidwire/utils.py
+++ b/bidwire/utils.py
@@ -13,7 +13,7 @@ def execute_parallel(fn, *iterables, num_threads=4):
         if more than one iterable is provided, then func must take that number of arguments
     num_threads (optional) -- the number of parallel threads to use
 
-    Returnss
+    Returns:
     a generator with the results of executing arg_tuples
 
     Raises:


### PR DESCRIPTION
Also:
* moved `ensure_absolute_url` as a shared piece into `utils.py` (not sure what a better place for this is; `document.py`?)
* added validation to `Document` that ensures that the `url` is indeed absolute
* added a `scrape_all_docs` command to `manage.py` to make it more convenient to exercise all scrapers locally