### PR TITLE
Comment-out no longer necessary migration that causes issues with future migrations

### DIFF
--- a/bidwire/alembic/versions/a1b42c9006a7_absolute_massgov_eopss_url.py
+++ b/bidwire/alembic/versions/a1b42c9006a7_absolute_massgov_eopss_url.py
@@ -23,20 +23,24 @@ depends_on = None
 
 
 def upgrade():
-    def ensure_absolute(url):
-        root_url = "https://www.mass.gov/"
-        if not url.startswith(root_url):
-            return parse.urljoin(root_url, url)
-        return url
-
-    # Attach to the migration's session
-    session = Session(bind=op.get_bind())
-    docs = session.query(Document).filter(
-        Document.site == Document.Site.MASSGOV_EOPSS.name).all()
-    for doc in docs:
-        doc.url = ensure_absolute(doc.url)
-    session.add_all(docs)
-    session.commit()
+    pass
+    # This migration was a one-time fix of data, and doesn't need to be run ever
+    # again, and gets in the way of future modifications to the Document class.
+    # It's left here for version number continuity, but is otherwise dead.
+#    def ensure_absolute(url):
+#        root_url = "https://www.mass.gov/"
+#        if not url.startswith(root_url):
+#            return parse.urljoin(root_url, url)
+#        return url
+#
+#    # Attach to the migration's session
+#    session = Session(bind=op.get_bind())
+#    docs = session.query(Document).filter(
+#        Document.site == Document.Site.MASSGOV_EOPSS.name).all()
+#    for doc in docs:
+#        doc.url = ensure_absolute(doc.url)
+#    session.add_all(docs)
+#    session.commit()
 
 
 def downgrade():


### PR DESCRIPTION
This migration references the Document class, and so it breaks if you change the Document class and re-run the migration (which might happen if you start with a clean DB schema in dev).

Since it was a one-time fix of the data in the DB, and isn't needed to keep the DB schema consistent, I'm commenting out the implementation, and just leaving the migration in place for version number compatibility.